### PR TITLE
chore(deps): upgrade brace-expansion to 5.0.5 to address CVE-2026-33750

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -40261,7 +40261,7 @@ const slashPattern = /\\\\/g;
 const openPattern = /\\{/g;
 const closePattern = /\\}/g;
 const commaPattern = /\\,/g;
-const periodPattern = /\\./g;
+const periodPattern = /\\\./g;
 exports.EXPANSION_MAX = 100_000;
 function numeric(str) {
     return !isNaN(str) ? parseInt(str, 10) : str.charCodeAt(0);
@@ -40388,7 +40388,9 @@ function expand_(str, max, isTop) {
             const x = numeric(n[0]);
             const y = numeric(n[1]);
             const width = Math.max(n[0].length, n[1].length);
-            let incr = n.length === 3 && n[2] !== undefined ? Math.abs(numeric(n[2])) : 1;
+            let incr = n.length === 3 && n[2] !== undefined ?
+                Math.max(Math.abs(numeric(n[2])), 1)
+                : 1;
             let test = lte;
             const reverse = y < x;
             if (reverse) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1439,9 +1439,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary

Regenerate `package-lock.json` to resolve `brace-expansion` from 5.0.3 → 5.0.5, fixing [Dependabot alert #20](https://github.com/fern-api/sync-openapi/security/dependabot/20) (GHSA-f886-m6hf-6m8v / CVE-2026-33750). Rebuild `dist/` to include the patched dependency.

No override or `package.json` change was needed — the existing `^5.0.2` range from `minimatch`/`glob` already allows 5.0.5; the lockfile was simply pinned to the older 5.0.3.

The `dist/index.js` diff reflects the upstream fix: zero-step increments are now sanitized to `Math.max(..., 1)` to prevent infinite loops and memory exhaustion.

## Review & Testing Checklist for Human

- [ ] Confirm `dist/index.js` changes align with [brace-expansion 5.0.5 release](https://github.com/juliangruber/brace-expansion/releases/tag/v5.0.5) (no unexpected modifications)
- [ ] Verify Dependabot alert #20 is dismissed after merge

### Notes

- No source code or `package.json` changes — only `package-lock.json` and the rebuilt `dist/index.js` bundle.

Link to Devin session: https://app.devin.ai/sessions/15636fcafbed48cea2c2447ead2650ef
Requested by: @davidkonigsberg