### PR TITLE
fix: upgrade vite to 6.4.2 to address CVE-2026-39363

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/node": "^20.0.0",
         "@vercel/ncc": "^0.36.1",
         "typescript": "^5.0.4",
+        "vite": "^6.4.2",
         "vitest": "^4.0.18"
       }
     },
@@ -2157,9 +2158,9 @@
       "license": "ISC"
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/node": "^20.0.0",
     "@vercel/ncc": "^0.36.1",
     "typescript": "^5.0.4",
+    "vite": "^6.4.2",
     "vitest": "^4.0.18"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

Upgrades `vite` from 6.4.1 to 6.4.2 to resolve [CVE-2026-39363](https://github.com/vitejs/vite/security/advisories/GHSA-p9ff-h696-f583) (High severity — Arbitrary File Read via Vite Dev Server WebSocket).

Previously `vite` was only a transitive dependency via `vitest`. This PR adds it as an explicit `devDependency` pinned to `^6.4.2` so npm resolves to at least the patched version.

## Review & Testing Checklist for Human

- [ ] Consider whether adding `vite` to the `overrides` section (like the existing `undici` override) would be preferable to adding it as a direct devDependency
- [ ] Run `npm audit` to confirm zero vulnerabilities after merging
- [ ] Run `npm test` to verify vitest still works correctly with vite 6.4.2

### Notes
- This is a dev-only dependency; the built `dist/` action output is unaffected since vite is not bundled into the action.
- Patch-level bump only (6.4.1 → 6.4.2), so breakage risk is minimal.

Link to Devin session: https://app.devin.ai/sessions/0ed0f94cf14a47d9b94b00d65bb38fe8
Requested by: @davidkonigsberg